### PR TITLE
Avoid error(s) if directories have been cleaned or removed recently

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
-    "load": "node loadCandidates",
+    "load": "mkdir -p data/candidates data/donations data/endorsements && node loadCandidates",
     "donors": "node loadDonors",
     "clean": "rm data/candidates/* && rm data/donations/* && rm data/endorsements/*",
     "loadfresh": "rm data/candidates/* && node loadCandidates"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
     "load": "mkdir -p data/candidates data/donations data/endorsements && node loadCandidates",
     "donors": "node loadDonors",
-    "clean": "rm data/candidates/* && rm data/donations/* && rm data/endorsements/*",
+    "clean": "rm -f data/candidates/* data/donations/* data/endorsements/*",
     "loadfresh": "rm data/candidates/* && node loadCandidates"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
     "load": "mkdir -p data/candidates data/donations data/endorsements && node loadCandidates",
-    "donors": "node loadDonors",
+    "donors": "mkdir -p data/donations && node loadDonors",
     "clean": "rm -f data/candidates/* data/donations/* data/endorsements/*",
     "loadfresh": "rm data/candidates/* && node loadCandidates"
   },


### PR DESCRIPTION
Tweak the `npm run load` command to make sure directories needed by the JS are present before proceeding.

This also now tweaks the `npm run clean` command to not get hangry if any of the `*` globs end up [getting passed through](https://wp.jochen.hayek.name/blog-en/2013/11/05/the-bashs-nullglob-is-rather-nice-to-use/) due to already empty.