### PR TITLE
Loop only through races, not counties, when loading pamphlet data

### DIFF
--- a/loadPamphletCandidates.js
+++ b/loadPamphletCandidates.js
@@ -36,7 +36,11 @@ module.exports = async () => {
   const dataBase = fermata.json(apiUrl)({e:electionId});
   const pamphBase = fermata.raw({base:webUrl});
 
-  const countyIds = ['03', '11'];
+  // API currently (2023-October) ignores this parameter…
+  const countyIds = [''];
+  // …so no need to fetch all races twice like we'd been.
+  //const countyIds = ['03', '11'];
+  
   const raceIds = CONFIG.raceIds;
 
   const pamphletCandidates = [];


### PR DESCRIPTION
Noticed while manually investigating some data loading questions that the Pamphlet API returns the same data for a race regardless of whether it's in a particular county. So we can finish in half the time if we just loop through one empty `''` county instead of both actual counties.

(I left the original code otherwise intact though, in case the API changes behavior in the future and does start/resume caring about counties again.)