### PR TITLE
Couple "empty startup" fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",
-    "start": "npm run develop",
+    "start": "mkdir -p data/candidates data/donations data/endorsements data/races data/offices data/guides && npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
-    "load": "mkdir -p data/candidates data/donations data/endorsements && node loadCandidates",
+    "load": "mkdir -p data/candidates && node loadCandidates",
     "donors": "mkdir -p data/donations && node loadDonors",
     "clean": "rm -f data/candidates/* data/donations/* data/endorsements/*",
     "loadfresh": "rm data/candidates/* && node loadCandidates"

--- a/schema/EndorsementsJson.js
+++ b/schema/EndorsementsJson.js
@@ -1,6 +1,6 @@
 // CandidatesJson @link(by: "uuid", from: "candidate")
 const EndorsementsJson = `
-type EndorsementsCsv implements Node {
+type EndorsementsJson implements Node {
   candidate:        String
   type:             String
   endorser:         String


### PR DESCRIPTION
This helps the Gatsby server start up even when it's not been fully populated:

* make sure all expected folders are present during `npm start` itself
* also fix up an `EndorsementsJson` schema crash when missing sample files
